### PR TITLE
update: Mbed CLI 2 でのビルドをサポート

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,12 @@ on:
       - "**.h"
       - "**.cpp"
       - "**/build.yml"
-      - "!tests/**"
   pull_request:
     paths:
       - "**/CMakeLists.txt"
       - "**.h"
       - "**.cpp"
       - "**/build.yml"
-      - "!tests/**"
   workflow_dispatch:
 
 jobs:
@@ -28,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [NUCLEO_F303K8, LPC1768]
+        target: [NUCLEO_F303K8]
         profile: [release, debug, develop]
 
     steps:
@@ -37,9 +35,7 @@ jobs:
       - name: build-mbed-cli
         run: |
           set -e
-          mbed new .
           mbed deploy
-          echo "int main(){}">source/main.cpp
           mbed compile -t GCC_ARM -m ${{ matrix.target }} --profile ${{ matrix.profile }}
 
   build-cli-v2:
@@ -50,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [NUCLEO_F303K8, LPC1768]
+        target: [NUCLEO_F303K8]
         profile: [release, debug, develop]
 
     steps:
@@ -59,6 +55,5 @@ jobs:
       - name: build-mbed-tools
         run: |
           set -e
-          mbed-tools new .
           mbed-tools deploy
           mbed-tools compile -t GCC_ARM -m ${{ matrix.target }} --profile ${{ matrix.profile }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,64 @@
+name: Build spirit
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "**/CMakeLists.txt"
+      - "**.h"
+      - "**.cpp"
+      - "**/build.yml"
+      - "!tests/**"
+  pull_request:
+    paths:
+      - "**/CMakeLists.txt"
+      - "**.h"
+      - "**.cpp"
+      - "**/build.yml"
+      - "!tests/**"
+  workflow_dispatch:
+
+jobs:
+  build-cli-v1:
+    container:
+      image: ghcr.io/armmbed/mbed-os-env:master-latest
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        target: [NUCLEO_F303K8, LPC1768]
+        profile: [release, debug, develop]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: build-mbed-cli
+        run: |
+          set -e
+          mbed new .
+          mbed deploy
+          echo "int main(){}">source/main.cpp
+          mbed compile -t GCC_ARM -m ${{ matrix.target }} --profile ${{ matrix.profile }}
+
+  build-cli-v2:
+    container:
+      image: ghcr.io/armmbed/mbed-os-env:master-latest
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        target: [NUCLEO_F303K8, LPC1768]
+        profile: [release, debug, develop]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: build-mbed-tools
+        run: |
+          set -e
+          mbed-tools new .
+          mbed-tools deploy
+          mbed-tools compile -t GCC_ARM -m ${{ matrix.target }} --profile ${{ matrix.profile }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# for Mbed CLI 1
 .build
 .mbed
 projectfiles
@@ -5,3 +6,6 @@ projectfiles
 mbed-os
 BUILD
 
+# for Mbed CLI 2
+.mbedbuild
+cmake_build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2023 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
+set(APP_TARGET mbed-can-motor-driver-for-spirit)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+project(${APP_TARGET})
+
+add_subdirectory(${MBED_PATH})
+
+add_subdirectory(spirit)
+
+add_executable(${APP_TARGET}
+    main.cpp
+)
+
+target_link_libraries(${APP_TARGET} mbed-os spirit spirit-platform-mbed)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,0 +1,7 @@
+{
+    "target_overrides": {
+        "NUCLEO_F303K8": {
+            "platform.stdio-baud-rate": 115200
+        }
+    }
+}

--- a/spirit.lib
+++ b/spirit.lib
@@ -1,1 +1,1 @@
-https://github.com/yutotnh/spirit#7fa672378fac485a417136e84aae3c9a3090cc15
+https://github.com/yutotnh/spirit#31a89908fdb69602bc2f7c73cd04ef45a04624f3


### PR DESCRIPTION
## Issue
<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->
- #1

## 対応内容
<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->
Mbed CLI 2 でのビルドをサポートする

ただし、 spirit の CMakeLists.txtの変更が不可欠

## テスト
<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->
GitHub Actions で Mbed CLI 2 のビルドチェックを追加する

## 残作業
<!--
  このPRでは解決していない内容について説明。
-->
なし